### PR TITLE
Remove extraneous filepath comments

### DIFF
--- a/qbox/forms.py
+++ b/qbox/forms.py
@@ -1,4 +1,3 @@
-# filepath: /e:/Documents/Web/qbox/qbox/forms.py
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, SubmitField, BooleanField, TextAreaField
 from wtforms.validators import DataRequired, Email, EqualTo, ValidationError

--- a/qbox/models.py
+++ b/qbox/models.py
@@ -1,4 +1,3 @@
-# filepath: /e:/Documents/Web/qbox/qbox/models.py
 from datetime import datetime
 from extensions import db  # Import db from extensions
 from flask_login import UserMixin


### PR DESCRIPTION
## Summary
- tidy `forms.py` and `models.py` by deleting leftover `# filepath:` comments

## Testing
- `pytest -q`
